### PR TITLE
fix: set default threat intelligence mode to null instead of alert

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -8,7 +8,7 @@ resource "azurerm_firewall" "fw" {
   firewall_policy_id  = try(var.instance.firewall_policy_id, null)
   dns_proxy_enabled   = try(var.instance.dns_proxy_enabled, false)
   dns_servers         = try(var.instance.dns_servers, null)
-  threat_intel_mode   = try(var.instance.threat_intel_mode, "Alert")
+  threat_intel_mode   = try(var.instance.threat_intel_mode, null)
   private_ip_ranges   = try(var.instance.private_ip_ranges, null)
   zones               = try(var.instance.zones, null)
   tags                = try(var.instance.tags, var.tags, {})


### PR DESCRIPTION
## Description

This PR sets threat intel mode to null instead of the default alert value.

This is because not all sku's accept this value. In this case is doesn't work with AZFW_Hub


## PR Checklist

- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking change (not backwards compatible with previous releases)