### PR TITLE
fix: remove redundant provider block

### DIFF
--- a/terraform.tf
+++ b/terraform.tf
@@ -8,7 +8,3 @@ terraform {
     }
   }
 }
-
-provider "azurerm" {
-  features {}
-}


### PR DESCRIPTION
## Description

This PR removes a redundant provider block, which was causing

```
Error: Module is incompatible with count, for_each, and depends_on

The module at module.firewall is a legacy module which contains its own local provider configurations, and so calls to it may not use the count, for_each, or depends_on arguments.
```

## PR Checklist

- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking change (not backwards compatible with previous releases)