### PR TITLE
fix: fix output to use public_ip_address_id for AZFW_VNet sku and revise complete example

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -48,11 +48,13 @@ module "public_ips" {
   version = "~> 2.0"
 
   configs = {
-    name           = module.naming.public_ip.name
-    location       = module.rg.groups.demo.location
-    resource_group = module.rg.groups.demo.name
+    pub1 = {
+      name           = module.naming.public_ip.name
+      location       = module.rg.groups.demo.location
+      resource_group = module.rg.groups.demo.name
 
-    zones = ["1", "2", "3"]
+      zones = ["1", "2", "3"]
+    }
   }
 }
 
@@ -82,7 +84,7 @@ module "firewall" {
     management_ip_configuration = {
       name                 = "config_mgt"
       subnet_id            = module.network.subnets.fwmgmt.id
-      public_ip_address_id = module.public_ip.configs.id
+      public_ip_address_id = module.public_ips.configs.pub1.id
     }
   }
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -8,6 +8,6 @@ output "public_ip_addresses" {
   value = var.instance.sku_name == "AZFW_Hub" ? (
     azurerm_firewall.fw.virtual_hub[0].public_ip_addresses
     ) : ([
-      for ip_config in azurerm_firewall.fw.ip_configuration : ip_config.public_ip_address
+      for ip_config in azurerm_firewall.fw.ip_configuration : ip_config.public_ip_address_id
   ])
 }


### PR DESCRIPTION
## Description

This PR fixes the output to use public_ip_address_id for AZFW_VNet sku and revise complete example

## PR Checklist

- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking change (not backwards compatible with previous releases)


## Related Issue(s)
Fixes #26 
